### PR TITLE
adds launch file and example urdf to ghost_example pkg

### DIFF
--- a/10_Examples/ghost_examples/launch/pub_sub_example.launch.py
+++ b/10_Examples/ghost_examples/launch/pub_sub_example.launch.py
@@ -1,0 +1,23 @@
+import launch
+import launch_ros
+
+def generate_launch_description():
+
+    publisher_node = launch_ros.actions.Node(
+        name = "publisher_node",
+        package = 'ghost_examples',
+        # This name is specified in the CmakeLists.txt file of this package 
+        executable = 'ros_publisher_example',
+    )
+
+    subscriber_node = launch_ros.actions.Node(
+        name='subscriber_node',
+        package= 'ghost_examples',
+        # This name is specified in the CmakeLists.txt file of this package 
+        executable='ros_subscriber_example_main',
+    )
+
+    return launch.LaunchDescription([
+        publisher_node,
+        subscriber_node
+    ])

--- a/10_Examples/ghost_examples/urdf/cylinder.xacro
+++ b/10_Examples/ghost_examples/urdf/cylinder.xacro
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<robot name="cylinder" xmlns:xacro="http://ros.org/wiki/xacro">
+    <link name="base_link">
+        <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+            <box size="0.0127 0.29 0.0254"/>
+        </geometry>
+            <material name="silver">
+                <color rgba="0.9 0.9 0.9 1.0"/>
+            </material>
+        </visual>
+
+        <!--Inertia estimated for solid cylinder of radius 9" and height 3" with mass 7kg-->
+        <inertial>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <mass value="10"/>
+            <inertia
+                ixx="0.094839" ixy="0.0" ixz="0.0"
+                iyy="0.094839" iyz="0.0"
+                izz="0.182903"/>
+        </inertial>
+
+        <gazebo>
+            <maxVel>3.0</maxVel>
+        </gazebo>
+    </link>
+</robot>


### PR DESCRIPTION
### Description
Adds launch and urdf directories to ghost_examples pkg with working launch file.

### Reviewers
Tag reviewers.

- Required: @MaxxWilson 


---
### Changelog
- All changes are in ghost_examples pkg 
- Adds launch directory to satisfy CMakeBuild launch directory requirement
- Launch file runs example publisher and subscriber nodes
- Adds urdf directory to satisfy CMakeBuild urdf directory requirement
- Adds basic cylinder.xacro file

### Testing
#### Automatic
- N/A
#### Manual
- run ros2 launch ghost_examples pub_sub_example.launch.py
- ros subscriber example node should print some time value in nanoseconds to console

### Checklist
- [X] Confirmed all tests pass on a clean build
- [X] Added reviewers in Github
- [X] Posted PR Summary to Discord PR's Channel
- [x] Ran uncrustify on any modified C++ files
- [x] Ran Colcon Lint for any modified CMakeLists.txt or Package.xml
