### PR TITLE
attempts to fix bugs

### DIFF
--- a/01_Libraries/ghost_control/include/ghost_control/models/dc_motor_model.hpp
+++ b/01_Libraries/ghost_control/include/ghost_control/models/dc_motor_model.hpp
@@ -63,6 +63,13 @@ public:
 	void setMotorEffort(double voltage_percent);
 
 	/**
+	 * @brief Set new motor input effort in millivolts
+	 *
+	 * @param voltage_mv voltage in millivolts
+	 */
+	void setMotorEffortMillivolts(double voltage_mv);
+
+	/**
 	 * @brief Set maximum motor current
 	 *
 	 * @param max_current Amps

--- a/01_Libraries/ghost_control/src/models/dc_motor_model.cpp
+++ b/01_Libraries/ghost_control/src/models/dc_motor_model.cpp
@@ -40,6 +40,10 @@ void DCMotorModel::setMotorEffort(double voltage_percent){
 	updateMotor();
 }
 
+void DCMotorModel::setMotorEffortMillivolts(double voltage_mv){
+	setMotorEffort(voltage_mv / nominal_voltage_);
+}
+
 void DCMotorModel::setMotorSpeedRPM(double current_speed){
 	curr_speed_ = current_speed / gear_ratio_;
 	updateMotor();

--- a/03_ROS/ghost_ros/src/ros_nodes/robot_state_machine_node.cpp
+++ b/03_ROS/ghost_ros/src/ros_nodes/robot_state_machine_node.cpp
@@ -148,17 +148,15 @@ RobotStateMachineNode::RobotStateMachineNode() :
 
 void RobotStateMachineNode::updateController(){
 	// Comparing msg ids ensures only one control update is performed for a given sensor update
-		// Clear actuator command msg
-		actuator_cmd_msg_ = ghost_msgs::msg::V5ActuatorCommand{};
+	// Clear actuator command msg
+	actuator_cmd_msg_ = ghost_msgs::msg::V5ActuatorCommand{};
 
+	teleop();
 
-		std::cout << "Update Controller" << std::endl;
-		teleop();
-
-		// Publish actuator command
-		actuator_cmd_msg_.header.stamp = get_clock()->now();
-		actuator_cmd_msg_.msg_id = curr_joystick_msg_id_;
-		actuator_command_pub_->publish(actuator_cmd_msg_);
+	// Publish actuator command
+	actuator_cmd_msg_.header.stamp = get_clock()->now();
+	actuator_cmd_msg_.msg_id = curr_joystick_msg_id_;
+	actuator_command_pub_->publish(actuator_cmd_msg_);
 }
 
 void RobotStateMachineNode::resetPose(){

--- a/03_ROS/ghost_sim/launch/start_sim.launch.py
+++ b/03_ROS/ghost_sim/launch/start_sim.launch.py
@@ -98,13 +98,13 @@ def generate_launch_description():
         arguments=['-d', rviz_config_path],
     )
 
-    # estimator_node = Node(
-    #     package='ghost_ros',
-    #     executable='ghost_estimator_node',
-    #     name='ghost_estimator_node',
-    #     output='screen',
-    #     parameters=[ghost_ros_base_dir + "/config/ghost_estimator_config.yaml"]
-    # )
+    estimator_node = Node(
+        package='ghost_ros',
+        executable='ghost_estimator_node',
+        name='ghost_estimator_node',
+        output='screen',
+        parameters=[ghost_ros_base_dir + "/config/ghost_estimator_config.yaml"]
+    )
 
     state_machine_node = Node(
         package='ghost_ros',
@@ -117,7 +117,7 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument(name='use_joy', default_value='true'),
         DeclareLaunchArgument(name='channel_id', default_value='1'),
-        DeclareLaunchArgument('sim_gui', default_value='false'),
+        DeclareLaunchArgument('sim_gui', default_value='true'),
         DeclareLaunchArgument('verbose', default_value='true'),
         simulation,
         # ground_truth_publisher,

--- a/03_ROS/ghost_sim/src/v5_robot_plugin.cpp
+++ b/03_ROS/ghost_sim/src/v5_robot_plugin.cpp
@@ -69,9 +69,9 @@ public:
 	Eigen::VectorXd encoder_velocities_;
 
 	// Motor Controller Gains
-	double feedforward_voltage_gain_ = 0.5;
+	double feedforward_voltage_gain_ = 1.0;
 	double feedforward_velocity_gain_ = 1.0;
-	double velocity_gain_ = 1.0;
+	double velocity_gain_ = 15.0;
 	double position_gain_ = 0.0;
 	double nominal_voltage_;
 
@@ -118,13 +118,13 @@ void V5RobotPlugin::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf){
 
 	// Initialize ROS Subscriptions
 	impl_->actuator_command_sub_ = impl_->ros_node_->create_subscription<ghost_msgs::msg::V5ActuatorCommand>(
-		"v5/actuator_command",
+		"v5/actuator_commands",
 		10,
 		[this](const ghost_msgs::msg::V5ActuatorCommand::SharedPtr msg){
 			std::unique_lock update_lock(impl_->actuator_update_callback_mutex);
 			for(const std::string &name : impl_->motor_names_){
 				// Get V5 Motor Command msg, Motor Model, and Motor Controller for each motor
-				const auto &motor_cmd_msg = msg->motor_commands[ghost_v5_config::motor_config_map.at(name).port - 1];
+				const auto &motor_cmd_msg = msg->motor_commands[ghost_v5_config::motor_config_map.at(name).port];
 				auto motor_model_ptr = impl_->motor_model_map_.at(name);
 				auto motor_controller_ptr = impl_->motor_controller_map_.at(name);
 
@@ -296,7 +296,7 @@ Eigen::VectorXd V5RobotPlugin::motorToJointTransform(Eigen::VectorXd motor_data)
 Eigen::VectorXd V5RobotPlugin::jointToMotorTransform(Eigen::VectorXd joint_data){
 	// Actuator Jacobian 6X8
 	// Joint Data 6X1
-	auto motor_data = impl_->actuator_jacobian_ * joint_data;
+	auto motor_data = impl_->actuator_jacobian_.inverse() * joint_data;
 	return motor_data;
 }
 
@@ -377,7 +377,7 @@ void V5RobotPlugin::updateMotorController(){
 		float velocity_feedback = (motor_controller_ptr->getVelocityCommand() - motor_velocities(motor_index)) * impl_->velocity_gain_;
 		float position_feedback = (angle_error) * impl_->position_gain_;
 
-		motor_model_ptr->setMotorEffort(voltage_feedforward + velocity_feedforward + velocity_feedback + position_feedback);
+		motor_model_ptr->setMotorEffortMillivolts(voltage_feedforward + velocity_feedforward + velocity_feedback + position_feedback);
 
 		motor_torques(motor_index) = motor_model_ptr->getTorqueOutput();
 		motor_index++;
@@ -390,11 +390,11 @@ void V5RobotPlugin::updateMotorController(){
 void V5RobotPlugin::applySimJointTorques(){
 	int joint_index = 0;
 	for(const std::string &name : impl_->joint_names_){
-		auto link = impl_->model_->GetJoint(name)->GetJointLink(1);
+		auto link = impl_->model_->GetJoint(name)->GetJointLink(0);
 		// For simulatilon stability, only apply torque if larger than a threshhold
 		if(std::abs(impl_->joint_cmd_torques_(joint_index)) > 1e-5){
 			link->AddRelativeTorque(ignition::math::v6::Vector3d(0.0, 0.0, impl_->joint_cmd_torques_(joint_index)));
-			std::cout << "joint_cmd_torque: " << impl_->joint_cmd_torques_(joint_index) << std::endl;
+			std::cout << name << " joint_torque: " << impl_->joint_cmd_torques_(joint_index) << std::endl;
 		}
 		joint_index++;
 	}

--- a/03_ROS/ghost_sim/test/test_publisher_v5_actuator_cmd.cpp
+++ b/03_ROS/ghost_sim/test/test_publisher_v5_actuator_cmd.cpp
@@ -47,7 +47,7 @@ ghost_msgs::msg::V5MotorCommand testPublisherV5ActuatorCmd::populateMotorCmd(con
 		v5_motor_cmd.desired_velocity = 0.5;
 		v5_motor_cmd.desired_torque = 0.0;
 		v5_motor_cmd.desired_voltage = 0.0;
-		v5_motor_cmd.current_limit = 5; // milliAmps
+		v5_motor_cmd.current_limit = 2500; // milliAmps
 
 		v5_motor_cmd.position_control = false;
 		v5_motor_cmd.velocity_control = true;
@@ -61,7 +61,7 @@ ghost_msgs::msg::V5MotorCommand testPublisherV5ActuatorCmd::populateMotorCmd(con
 		v5_motor_cmd.desired_velocity = 0.0;
 		v5_motor_cmd.desired_torque = 0.0;
 		v5_motor_cmd.desired_voltage = 0.0;
-		v5_motor_cmd.current_limit = 5; // milliAmps
+		v5_motor_cmd.current_limit = 2500; // milliAmps
 
 		v5_motor_cmd.position_control = false;
 		v5_motor_cmd.velocity_control = true;

--- a/03_ROS/ghost_sim/urdf/ghost1_sim_base.xacro
+++ b/03_ROS/ghost_sim/urdf/ghost1_sim_base.xacro
@@ -18,20 +18,20 @@
                 steering_joint_left
                 steering_joint_right
                 steering_joint_back
-                steering_top_test
                 wheel_joint_left
                 wheel_joint_right
                 wheel_joint_back
+                steering_top_test
                 wheel_top_test
             </joint_names>
             <!-- Motor names must be formatted in this manner in order to index actuator jacobian -->
             <motor_names>
                 DRIVE_LEFT_FRONT_LEFT_MOTOR
                 DRIVE_LEFT_FRONT_RIGHT_MOTOR
-                DRIVE_LEFT_BACK_LEFT_MOTOR
-                DRIVE_LEFT_BACK_RIGHT_MOTOR
                 DRIVE_RIGHT_FRONT_LEFT_MOTOR
                 DRIVE_RIGHT_FRONT_RIGHT_MOTOR
+                DRIVE_LEFT_BACK_LEFT_MOTOR
+                DRIVE_LEFT_BACK_RIGHT_MOTOR
                 DRIVE_RIGHT_BACK_LEFT_MOTOR
                 DRIVE_RIGHT_BACK_RIGHT_MOTOR
             </motor_names>
@@ -68,15 +68,18 @@
             <!-- This matrix describes the relationship between motor velocities and joint velocities -->
             <!-- Width = # Motors, Height = # Joints -->
             <actuator_jacobian>
-              0    0    0    0    0    0    0    0
-              0    0    0    0    0    0    0    0 
-              0    0    0    0    0    0    0    0
-            1.0    0    0    0    0    0    0    0
-              0    0    0    0    0    0    0    0
-              0    0    0    0    0    0    0    0
-              0    0    0    0    0    0    0    0
-              0    0    0    0    0    0    0    0
+                0.144     0.144       0           0           0           0           0           0
+                0         0           0.144       0.144       0           0           0           0
+                0         0           0           0           0.144       0.144       0           0
+                0         0           0           0           0           0           0           0
+                0         0           0           0           0           0           0           0
+                0         0           0           0           0           0           0           0
+                0         0           0           0           0           0           0           0
+                0         0           0           0           0           0           0           0
             </actuator_jacobian>
+                <!-- 0.361     -0.361      0           0           0           0           0           0 -->
+                <!-- 0         0           0.361     -0.361        0           0           0           0 -->
+                <!-- 0         0           0           0           0.361     -0.361        0           0 -->
 
             <!-- This matrix describes the relationship between the encoders and the joints -->
             <!-- This encoder matrix does not include encoders within motors. The relation ship between motor encoders and 

--- a/03_ROS/ghost_sim/urdf/ghost1_sim_base.xacro
+++ b/03_ROS/ghost_sim/urdf/ghost1_sim_base.xacro
@@ -71,15 +71,12 @@
                 0.144     0.144       0           0           0           0           0           0
                 0         0           0.144       0.144       0           0           0           0
                 0         0           0           0           0.144       0.144       0           0
-                0         0           0           0           0           0           0           0
-                0         0           0           0           0           0           0           0
-                0         0           0           0           0           0           0           0
+                0.361     -0.361      0           0           0           0           0           0
+                0         0           0.361     -0.361        0           0           0           0
+                0         0           0           0           0.361     -0.361        0           0
                 0         0           0           0           0           0           0           0
                 0         0           0           0           0           0           0           0
             </actuator_jacobian>
-                <!-- 0.361     -0.361      0           0           0           0           0           0 -->
-                <!-- 0         0           0.361     -0.361        0           0           0           0 -->
-                <!-- 0         0           0           0           0.361     -0.361        0           0 -->
 
             <!-- This matrix describes the relationship between the encoders and the joints -->
             <!-- This encoder matrix does not include encoders within motors. The relation ship between motor encoders and 


### PR DESCRIPTION
# PR Summary
### Description
Fixes robot state machine example for testing the V5 Robot Gazebo Plugin.

### Reviewers
Tag reviewers.

- Required: @melissajcruz @JakeWendling 

---
### Changelog
- Adds a setMotorEffortMillivolts interface to DC Motor Model
- Fixes small bugs in V5 Robot Plugin (off-by-one indexing, missing inverse)
- Adds Swerve drive Jacobian for testing
- Fixes joystick launch file use

### Reviewer Guide
This is meant to discuss status of development of this plugin / feature (which is why it's not getting PR'ed to develop).
Here are some issues I noticed so far and open questions I have:
- We don't have unit testing for the math going on behind the scenes in the simulator plugin. This makes it really difficult to debug and guarantee functionality for edge-cases.
- I still get the feeling we are lacking a good "Robot" interface class. We are definitely going to use the joint <-> actuator jacobians in control and estimation, so why isn't there a single shared interface? The gazebo / ros functionality should be totally separated from the kinematics/dynamics math implementations.
- Following the previous, it is still tedious and annoying to address motors via the ROS msg.