### PR TITLE
Autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Follow Link: https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.
 
 ### Repo Setup
 #### Download Repository
-```
+```sh
 cd
 git clone git@github.com:VEXU-GHOST/VEXU_GHOST.git
 cd VEXU_GHOST
@@ -31,7 +31,7 @@ git submodule init
 git submodule update --recursive
 ```
 #### Add Setup to ~/.bashrc (which "configures" a new terminal when you open it)
-```
+```sh
 echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 echo "source ~/VEXU_GHOST/install/setup.bash" >> ~/.bashrc
 echo 'export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH' >> ~/.bashrc
@@ -39,24 +39,30 @@ echo 'export GAZEBO_PLUGIN_PATH=$HOME/VEXU_GHOST/build/ghost_sim:$GAZEBO_PLUGIN_
 ```
 
 #### Update Dependencies
-```
+```sh
 ./scripts/update_dependencies.sh
 ```
 
 #### Build Submodules
-```
+```sh
 source ~/.bashrc
 ./scripts/setup_submodules.sh
 ```
 
 #### Build Repository
-```
+```sh
 source ~/.bashrc
 ./scripts/build.sh -r
 ```
 
 #### Start Simulator
-```
+```sh
 source ~/.bashrc
 ./scripts/launch_sim.sh
+```
+
+#### Add yourself to the dialout group (only needed for real robot)
+
+```sh
+sudo usermod -a -G dialout $USER
 ```

--- a/scripts/hardware/jetson_startup.sh
+++ b/scripts/hardware/jetson_startup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# put the path to this script in `gnome-session-properties` (likely /home/ghost2/VEXU_GHOST/scripts/hardware/jetson_startup.sh)
+
 source ~/.bashrc
 
 # https://askubuntu.com/questions/581922/export-display-value-in-shell-script

--- a/scripts/hardware/jetson_startup.sh
+++ b/scripts/hardware/jetson_startup.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
 source ~/.bashrc
 
-gnome-terminal --full-screen -- "./launch_hardware.sh"
+# https://askubuntu.com/questions/581922/export-display-value-in-shell-script
+export DISPLAY=$(w -h $USER | awk '$2 ~ /:[0-9.]*/{print $2}')
+
+logger "RUNNING THE gnome-terminal START LOOP NOW"
+
+until gnome-terminal --wait --full-screen -- "$HOME/VEXU_GHOST/scripts/launch_hardware.sh"; do
+	logger "RUNNING GNOME TERINMAL FAILED AND TRYING AGAIN IN 3 sec"
+	sleep 3
+done;
+
+logger "DONE RUNNING THE LOOP"

--- a/scripts/launch_hardware.sh
+++ b/scripts/launch_hardware.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
+logger "RUNNING launch_hardware.sh"
+cd ~/VEXU_GHOST
+source ~/.bashrc
+
+# idk if we need to double it given it's already in bashrc but it works so don't touch it
 source /opt/ros/humble/setup.bash
-source ~/rplidar_ros/install/setup.bash
 source ~/VEXU_GHOST/install/setup.bash
+export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH
+export GAZEBO_PLUGIN_PATH=$HOME/VEXU_GHOST/build/ghost_sim:$GAZEBO_PLUGIN_PATH
 
-export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/${LD_LIBRARY_PATH:+:$LD_LIBRAR>
-export DISPLAY=:0.0
+# log to stdout AND /var/log/syslog
+ros2 launch ghost_over_under hardware.launch.py 2>&1 | tee /dev/tty |& logger
 
-
-#ros2 launch ghost_ros hardware.launch.py
-sleep 10
+logger "RUNNING ros2 launch ghost_over_under DONE"
+logger ${PIPESTATUS}


### PR DESCRIPTION
# PR Summary
### Description
Fix autostart scripts



### Reviewers
Tag reviewers.

- Required: @Maxx
  
- Optional: @Melissa, @Jake

---
### Changelog
- Modify launch_hardware and jetson_startup scripts to run the right things
- Made README pretty with code block type annotations

### Reviewer Guide
- TONS of logging to /var/log/syslog
- Must add the script location to 'gnome-session-properties' to get it to autostart on boot, and autologin must be enabled.

### Testing
#### Manual
- Turn the jetson on
- See that it works
- (unfortunately no good tests, ik)

### Documentation
- N/A

### Checklist
- [x] Confirmed all tests pass on a clean build
- [x] Added reviewers in Github
- [ ] Posted PR Summary to Discord PR's Channel
- [x] Ran uncrustify on any modified C++ files
- [x] Ran Colcon Lint for any modified CMakeLists.txt or Package.xml
