### PR TITLE
Blink screen heartbeat based on ROS connection

### DIFF
--- a/02_V5/ghost_pros/include/ghost_v5/screen/screen_interface.hpp
+++ b/02_V5/ghost_pros/include/ghost_v5/screen/screen_interface.hpp
@@ -37,6 +37,8 @@ public:
 
 	void updateScreen();
 
+	void updateLastConnectionTime();
+
 	void setTitle(const std::string& title);
 
 	int getRefreshRateMilliseconds(){
@@ -53,6 +55,7 @@ private:
 	std::deque<std::string> print_queue_;
 	std::vector<std::string> screen_buffer_;
 	uint32_t last_update_time_ = 0;
+	uint32_t last_connection_time_ = 0;
 	int curr_row_ = 2;
 
 	// V5 Screen Params

--- a/02_V5/ghost_pros/src/ghost_v5/screen/screen_interface.cpp
+++ b/02_V5/ghost_pros/src/ghost_v5/screen/screen_interface.cpp
@@ -41,16 +41,16 @@ void ScreenInterface::updateScreen(){
 		return;
 	}
 
-	// This pulses the title on and off at regular rate so we know the program is alive.
+	// This pulses the title on and off at regular rate so we know the program is connected to ROS.
 	if((count % (1000 / REFRESH_RATE_MS)) == 0){
-		if(heartbeat_toggle){
-			auto title_str = std::string("- ") + title_string_ + std::string(" -");
-			pros::screen::print(pros::text_format_e_t::E_TEXT_LARGE_CENTER, 0, title_str.c_str());
-		}
-		else{
-			auto title_str = std::string("  ") + title_string_ + std::string("  ");
-			pros::screen::print(pros::text_format_e_t::E_TEXT_LARGE_CENTER, 0, title_str.c_str());
-		}
+		std::string title_str;
+		// enables or disables based on time AND blinks based on heartbeat toggle
+		if (last_connection_time_ + 1000 > pros::millis() && heartbeat_toggle)
+			title_str = std::string("======= ") + title_string_ + std::string(" =======");
+		else
+			title_str = std::string("        ") + title_string_ + std::string("        ");
+
+		pros::screen::print(pros::text_format_e_t::E_TEXT_LARGE_CENTER, 0, title_str.c_str());
 		heartbeat_toggle = !heartbeat_toggle;
 	}
 	count++;
@@ -82,6 +82,11 @@ void ScreenInterface::updateScreen(){
 
 void ScreenInterface::setTitle(const std::string& title){
 	title_string_ = title;
+}
+
+
+void ScreenInterface::updateLastConnectionTime(){
+	last_connection_time_ = pros::millis();
 }
 
 std::vector<std::string> ScreenInterface::wrapStringToLineLength(std::string str, int line_len){

--- a/02_V5/ghost_pros/src/ghost_v5/serial/v5_serial_node.cpp
+++ b/02_V5/ghost_pros/src/ghost_v5/serial/v5_serial_node.cpp
@@ -50,6 +50,7 @@ bool V5SerialNode::readV5ActuatorUpdate(){
 	int msg_len;
 	bool msg_recieved = serial_base_interface_->readMsgFromSerial(new_msg_, actuator_command_msg_len_);
 	if(msg_recieved){
+		v5_globals::screen_interface_ptr->updateLastConnectionTime();
 		std::unique_lock<pros::Mutex> actuator_lock(v5_globals::actuator_update_lock);
 		updateActuatorCommands(new_msg_);
 		actuator_lock.unlock();


### PR DESCRIPTION
# PR Summary
PR Link: https://github.com/VEXU-GHOST/VEXU_GHOST/pull/44

### Description
The heartbeat on the screen now only turns on when ROS is connected.

### Reviewers

- Required: @Maxx
  
- Optional: @Melissa, @Jake

---
### Changelog
- Serial informs global screen object when every time it receives a new message
- Screen class keeps track of the time of last message
- If there was a message within the last 1 second, blink heartbeat, else disable heartbeat 

### Reviewer Guide
See Changelog

### Testing
#### Automatic
none
#### Manual
[video](https://photos.app.goo.gl/d7PcjT12YibLsJvx7)

### Documentation
none

### Checklist
- [x] Confirmed all tests pass on a clean build
- [x] Added reviewers in Github
- [x] Posted PR Summary to Discord PR's Channel
- [x] Ran uncrustify on any modified C++ files
- [x] Ran Colcon Lint for any modified CMakeLists.txt or Package.xml
