### PR TITLE
removes cmake linting

### DIFF
--- a/03_ROS/ghost_motion_planner_core/CMakeLists.txt
+++ b/03_ROS/ghost_motion_planner_core/CMakeLists.txt
@@ -91,16 +91,4 @@ install(
   DESTINATION include
 )
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
 ament_package()

--- a/cmake/GhostConfig.cmake
+++ b/cmake/GhostConfig.cmake
@@ -34,18 +34,3 @@ add_definitions(-DGHOST_JETSON=1)
 add_definitions(-DGHOST_V5_BRAIN=2)
 
 add_definitions(-DGHOST_DEVICE=1)
-
-##########################
-### Autolinter Testing ###
-##########################
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()


### PR DESCRIPTION
# PR Summary
PR Link: https://github.com/VEXU-GHOST/VEXU_GHOST/pull/99

### Description
Removes linting from CMake.

### Reviewers
- Required: @MaxxWilson 
---
### Changelog
- Removes linter flags from base CMake config.
- Removes duplicate linter flags from motion planner CMake.