### PR TITLE
Feature/power button

### DIFF
--- a/scripts/hardware/service.sh
+++ b/scripts/hardware/service.sh
@@ -45,6 +45,7 @@ ExecStart=-/sbin/agetty --autologin ghost --keep-baud 115200,57600,38400,9600 %I
 EOF
 	sudo systemctl daemon-reload
 	sudo systemctl restart serial-getty@ttyTCU0.service
+    sudo systemctl disable --now gdm3
 	echo "$USER ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/nopasswd-$USER
 
 	;;

--- a/scripts/hardware/service.sh
+++ b/scripts/hardware/service.sh
@@ -45,7 +45,7 @@ ExecStart=-/sbin/agetty --autologin ghost --keep-baud 115200,57600,38400,9600 %I
 EOF
 	sudo systemctl daemon-reload
 	sudo systemctl restart serial-getty@ttyTCU0.service
-    sudo systemctl disable --now gdm3
+	sudo systemctl disable --now gdm3
 	echo "$USER ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/nopasswd-$USER
 
 	;;


### PR DESCRIPTION
i am not writing a changelog. disable gui on boot unless you run `sudo systemctl start gdm3`. GDM takes over the power button and breaks it, since we run headless its useless most of the time, so i'm removing it.