### PR TITLE
localization: source the lidar offset from the URDF via TF

### DIFF
--- a/03_ROS/ghost_localization/CMakeLists.txt
+++ b/03_ROS/ghost_localization/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(ghost_estimation REQUIRED)
 find_package(ghost_util REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(ghost_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 include_directories(include)
 
@@ -45,6 +46,7 @@ add_executable(ekf_pf_node
 ament_target_dependencies(ekf_pf_node
   rclcpp
   tf2_msgs
+  tf2_ros
   sensor_msgs
   visualization_msgs
   nav_msgs

--- a/03_ROS/ghost_localization/include/ghost_localization/ekf_pf_node.hpp
+++ b/03_ROS/ghost_localization/include/ghost_localization/ekf_pf_node.hpp
@@ -44,6 +44,8 @@
 #include "sensor_msgs/msg/joint_state.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
 #include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
@@ -61,6 +63,11 @@ public:
 
 private:
   void LoadROSParams();
+
+  // Reads the lidar pose (base_link -> lidar_link) from TF and writes it into
+  // config_params.laser_offset_*. The URDF/robot_state_publisher is the single
+  // source of truth for that offset.
+  void LoadLidarTransform();
 
   // Subscribers
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr ekf_odom_sub_;
@@ -86,6 +93,10 @@ private:
   void DrawPredictedScan(visualization_msgs::msg::MarkerArray & viz_msg);
   void PublishMapViz();
   void PublishRobotPose();
+
+  // TF (reads base_link -> lidar_link for the laser offset)
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   // Particle Filter
   particle_filter::ParticleFilter particle_filter_;

--- a/03_ROS/ghost_localization/package.xml
+++ b/03_ROS/ghost_localization/package.xml
@@ -15,6 +15,7 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>tf2_msgs</depend>
+  <depend>tf2_ros</depend>
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/03_ROS/ghost_localization/src/ekf_pf_node.cpp
+++ b/03_ROS/ghost_localization/src/ekf_pf_node.cpp
@@ -21,6 +21,7 @@
 #include "eigen3/Eigen/Geometry"
 #include "ghost_localization/ekf_pf_node.hpp"
 #include "ghost_util/angle_util.hpp"
+#include "tf2/time.h"
 #include "math/line2d.h"
 #include "math/math_util.h"
 #include "util/timer.h"
@@ -71,6 +72,7 @@ EkfPfNode::EkfPfNode()
   this->set_parameter(use_sim_time_param);
 
   LoadROSParams();
+  LoadLidarTransform();
 
   rclcpp::QoS qos_profile(1);
   qos_profile.transient_local();
@@ -143,17 +145,12 @@ void EkfPfNode::LoadROSParams()
   config_params.k8 = get_parameter("particle_filter.k8").as_double();
   config_params.k9 = get_parameter("particle_filter.k9").as_double();
 
-  declare_parameter("particle_filter.laser_offset_x", 0.0);
-  declare_parameter("particle_filter.laser_offset_y", 0.0);
-  declare_parameter("particle_filter.laser_angle_offset", 0.0);
+  // laser_offset_x / laser_offset_y / laser_angle_offset come from TF
+  // (base_link -> lidar_link), set in LoadLidarTransform().
   declare_parameter("particle_filter.min_update_dist", 0.0);
   declare_parameter("particle_filter.min_update_angle", 0.0);
   declare_parameter("particle_filter.max_update_yaw_velocity", 0.0);
   declare_parameter("particle_filter.max_update_tilt_velocity", 0.0);
-  config_params.laser_offset_x = get_parameter("particle_filter.laser_offset_x").as_double();
-  config_params.laser_offset_y = get_parameter("particle_filter.laser_offset_y").as_double();
-  config_params.laser_angle_offset =
-    get_parameter("particle_filter.laser_angle_offset").as_double();
   config_params.min_update_dist = get_parameter("particle_filter.min_update_dist").as_double();
   config_params.min_update_angle = get_parameter("particle_filter.min_update_angle").as_double();
   config_params.max_update_yaw_velocity = get_parameter(
@@ -187,6 +184,43 @@ void EkfPfNode::LoadROSParams()
   config_params.skip_index_min = get_parameter("particle_filter.skip_index_min").as_int();
   config_params.skip_index_max = get_parameter("particle_filter.skip_index_max").as_int();
   publish_tf_ = get_parameter("particle_filter.publish_tf").as_bool();
+}
+
+void EkfPfNode::LoadLidarTransform()
+{
+  declare_parameter("base_frame", "base_link");
+  declare_parameter("lidar_frame", "lidar_link");
+  const std::string base_frame = get_parameter("base_frame").as_string();
+  const std::string lidar_frame = get_parameter("lidar_frame").as_string();
+
+  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+  // The base_link -> lidar_link transform is published by robot_state_publisher
+  // from the URDF (the single source of truth for the lidar pose). Block briefly
+  // for it; the TransformListener fills the buffer on its own thread.
+  try {
+    const auto tf = tf_buffer_->lookupTransform(
+      base_frame, lidar_frame, tf2::TimePointZero, tf2::durationFromSec(10.0));
+    config_params.laser_offset_x = tf.transform.translation.x;
+    config_params.laser_offset_y = tf.transform.translation.y;
+    config_params.laser_angle_offset =
+      2.0 * std::atan2(tf.transform.rotation.z, tf.transform.rotation.w);
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Lidar offset from TF %s->%s: x=%.4f y=%.4f yaw=%.4f",
+      base_frame.c_str(), lidar_frame.c_str(),
+      config_params.laser_offset_x, config_params.laser_offset_y,
+      config_params.laser_angle_offset);
+  } catch (const tf2::TransformException & ex) {
+    config_params.laser_offset_x = 0.0;
+    config_params.laser_offset_y = 0.0;
+    config_params.laser_angle_offset = 0.0;
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "No %s->%s transform (%s); using zero lidar offset. Is robot_state_publisher running?",
+      base_frame.c_str(), lidar_frame.c_str(), ex.what());
+  }
 }
 
 void EkfPfNode::LaserCallback(const sensor_msgs::msg::LaserScan::SharedPtr msg)

--- a/11_Robots/ghost_push_back/config/base_ros_config.yaml
+++ b/11_Robots/ghost_push_back/config/base_ros_config.yaml
@@ -112,9 +112,9 @@ ekf_pf_node:
       # You can tune this up and down based on performance, but I recommend starting from some initial guess based on robot config or data
 
       # Robot Constants
-      laser_offset_x: -0.1143
-      laser_offset_y: 0.1525
-      laser_angle_offset: 0.0
+      # NOTE: the lidar offset (laser_offset_x/y, laser_angle_offset) now comes
+      # from TF (base_link -> lidar_link, published by robot_state_publisher from
+      # the URDF). See 11_Robots/ghost_push_back/urdf/ghost_push_back.urdf.xacro.
 
       # RPLidar A1 datasheet
       range_min: 0.15

--- a/11_Robots/ghost_push_back/launch/hardware.launch.py
+++ b/11_Robots/ghost_push_back/launch/hardware.launch.py
@@ -24,6 +24,18 @@ def generate_launch_description():
         parameters=[base_ros_config_file],
     )
 
+    # Publish the robot transform tree (base_link -> sensor frames) from the URDF
+    # so rviz, costmaps, and the particle filter share one source of truth for
+    # sensor poses.
+    urdf_path = os.path.join(ghost_push_back_base_dir, "urdf", "ghost_push_back.urdf.xacro")
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="screen",
+        parameters=[{"robot_description": xacro.process_file(urdf_path).toxml()}],
+    )
+
     rplidar_node = Node(
         package="rplidar_ros",
         executable="rplidar_node",
@@ -96,6 +108,7 @@ def generate_launch_description():
 
     return LaunchDescription([
         DeclareLaunchArgument("robot_name", default_value="None"),
+        robot_state_publisher,
         rplidar_node,
         # realsense_node,
         bag_recorder_service,

--- a/11_Robots/ghost_push_back/urdf/ghost_push_back.urdf.xacro
+++ b/11_Robots/ghost_push_back/urdf/ghost_push_back.urdf.xacro
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<robot name="ghost_push_back" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!--
+    Transform-tree description for the push-back robot.
+
+    base_link is the robot body frame (REP-105); sensor frames hang off it via
+    fixed joints. robot_state_publisher broadcasts the tree so rviz, costmaps,
+    and the particle filter share one source of truth for sensor poses. Add a
+    sensor by copying the lidar link+joint block.
+  -->
+
+  <!-- base_link: the robot body frame. -->
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <box size="0.35 0.35 0.1"/>
+      </geometry>
+      <material name="grey">
+        <color rgba="0.4 0.4 0.4 1.0"/>
+      </material>
+    </visual>
+  </link>
+
+  <!-- RPLidar A1. Offset matches the ekf_pf_node laser_offset_* params; z is
+       cosmetic for the 2D particle filter, set it to the real mounting height
+       for 3D viz. -->
+  <link name="lidar_link">
+    <visual>
+      <geometry>
+        <cylinder radius="0.038" length="0.04"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0.05 0.05 0.05 1.0"/>
+      </material>
+    </visual>
+  </link>
+
+  <joint name="base_link_to_lidar_link" type="fixed">
+    <parent link="base_link"/>
+    <child link="lidar_link"/>
+    <origin xyz="-0.1143 0.1525 0.2" rpy="0 0 0"/>
+  </joint>
+
+</robot>


### PR DESCRIPTION
Publish the robot transform tree from a URDF: add ghost_push_back/urdf/ghost_push_back.urdf.xacro (base_link -> lidar_link at the measured offset) and a robot_state_publisher in hardware.launch.py. This fixes lidar_link, which was previously stamped on /scan but never broadcast on TF.

ekf_pf_node now reads base_link -> lidar_link from TF on startup and uses it for the laser offset, so the lidar pose lives in exactly one place (the URDF) instead of being duplicated in base_ros_config.yaml. The laser_offset_* params are removed from the config; add tf2_ros as a dependency.

# PR Summary
PR Link: INSERT-LINK-HERE

Issue Link: INSERT-LINK-HERE

### Description
Add a single line summary describing the purpose of this PR.

### Reviewers
Tag reviewers.

- Required:
  
- Optional:

---
### Changelog
- Add a bulleted list of major changes

### Reviewer Guide
This is the most important part!
- No one is going to read every line of every PR, so you need to tell the reviewers what they are looking for.
- Point out lines you want feedback on or feel unsure about.
- Highlight major changes that other members need to know about.

### Testing
#### Automatic
- Describe test cases that are covered by unit tests
#### Manual
- Describe any manual testing (launch files, visualizations, etc.)

### Documentation
- Link any relevant documentation

### Checklist
- [ ] Confirmed all tests pass on a clean build
- [ ] Added reviewers in Github
- [ ] Posted PR Summary to Discord PR's Channel
- [ ] Ran uncrustify on any modified C++ files
- [ ] Ran Colcon Lint for any modified CMakeLists.txt or Package.xml
